### PR TITLE
Changed pydevd to pydevd_pycharm

### DIFF
--- a/remote_debugger.py
+++ b/remote_debugger.py
@@ -15,7 +15,7 @@ http://code.blender.org/2015/10/debugging-python-code-with-pycharm/
 bl_info = {
     'name': 'Remote debugger',
     'author': 'Sybren A. Stüvel',
-    'version': (0, 4),
+    'version': (0, 4, 1),
     'blender': (2, 80, 0),
     'location': 'Press [Space], search for "debugger"',
     'category': 'Development',
@@ -130,8 +130,8 @@ class DEBUG_OT_connect_debugger_pycharm(bpy.types.Operator):
         if not any('pycharm-debug' in p for p in sys.path):
             sys.path.append(eggpath)
 
-        import pydevd
-        pydevd.settrace('localhost', port=1090, stdoutToServer=True, stderrToServer=True,
+        import pydevd_pycharm
+        pydevd_pycharm.settrace('localhost', port=1090, stdoutToServer=True, stderrToServer=True,
                         suspend=False)
 
         return {'FINISHED'}


### PR DESCRIPTION
Hi, I was follwing your blog post at https://code.blender.org/2015/10/debugging-python-code-with-pycharm/

And it helped me set up debugging in Blender. But I think pycharm has changed since you wrote it in 2015. At least when setting up a remote debugger in my Windows 10 2019.3 installation it wants to  use their own module pydevd_pycharm instead of just pydevd:
![image](https://user-images.githubusercontent.com/16946048/75623469-f1f6a180-5bb2-11ea-8c29-4572f9130f36.png)
